### PR TITLE
Tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ sudo apt install socat
 
     ```sh
     minikube start
+
+    # If you haven't, enable ingress.
+    minikube addons enable ingress
     ```
 
 2. The easiest way to deploy the whole infrastructure is using helmfile:
@@ -64,11 +67,12 @@ sudo apt install socat
     127.0.0.1 bookem.local
     127.0.0.1 api.bookem.local
     127.0.0.1 db.bookem.local
+    127.0.0.1 jaeger.bookem.local
     ```
 
     - If you're on Linux:
     ```yml
     # /etc/hosts
 
-    127.0.0.1 bookem.local api.bookem.local db.bookem.local
+    127.0.0.1 bookem.local api.bookem.local db.bookem.local jaeger.bookem.local
     ```

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -24,3 +24,6 @@ releases:
 
   - name: adminer
     chart: ./adminer
+
+  - name: jaeger
+    chart: ./jaeger

--- a/jaeger/.helmignore
+++ b/jaeger/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/jaeger/Chart.yaml
+++ b/jaeger/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: jaeger
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/jaeger/templates/configmap.yml
+++ b/jaeger/templates/configmap.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.appName }}
+  namespace: {{ .Values.namespace }}
+data:
+  SPAN_STORAGE_TYPE: {{ .Values.configmap.data.SPAN_STORAGE_TYPE | quote }}
+  BADGER_EPHEMERAL: {{ .Values.configmap.data.BADGER_EPHEMERAL | quote }}
+  BADGER_DIRECTORY_VALUE: {{ .Values.configmap.data.BADGER_DIRECTORY_VALUE | quote }}
+  BADGER_DIRECTORY_KEY: {{ .Values.configmap.data.BADGER_DIRECTORY_KEY | quote }}

--- a/jaeger/templates/deployment.yml
+++ b/jaeger/templates/deployment.yml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.appName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.appName }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.appName }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.appName }}
+    spec:
+      containers:
+        - name: {{ .Values.appName }}
+          image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.port.ui}}
+            - containerPort: {{ .Values.port.colelctor}}
+            - containerPort: {{ .Values.port.otlp}}
+          envFrom:
+          - configMapRef:
+              name: {{ .Values.appName }}
+
+          volumeMounts:
+            - name: badger-storage
+              mountPath: {{ .Values.volumes.dbStorage.path }}
+      volumes:
+        - name: badger-storage
+          persistentVolumeClaim:
+            claimName: {{ .Values.appName }}

--- a/jaeger/templates/ingress.yml
+++ b/jaeger/templates/ingress.yml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.appName }}
+  namespace: {{ .Values.namespace }}
+spec:
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.appName }}
+                port:
+                  number: {{ .Values.port.outside }}

--- a/jaeger/templates/pvc.yml
+++ b/jaeger/templates/pvc.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.appName }}
+  namespace: {{ .Values.namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.volumes.dbStorage.space }}
+  storageClassName: standard

--- a/jaeger/templates/service.yml
+++ b/jaeger/templates/service.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.appName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.appName }}
+spec:
+  selector:
+    app: {{ .Values.appName }}
+
+  ports:
+    - protocol: TCP
+      name: ui
+      targetPort: {{ .Values.port.ui }}
+      port: {{ .Values.port.outside }}
+    - protocol: TCP
+      name: otlp-http
+      port: {{ .Values.port.otlp }}
+      targetPort: {{ .Values.port.otlp }}

--- a/jaeger/values.yaml
+++ b/jaeger/values.yaml
@@ -1,0 +1,27 @@
+appName: jaeger
+namespace: default
+replicas: 1
+image:
+  name: jaegertracing/all-in-one
+  tag: "1.53"
+
+port:
+  outside: 80 # Used outside the cluster
+  ui: 16686
+  colelctor: 14268
+  otlp: 4318 # 4318 is for HTTP while 4317 is for gRPC
+
+ingress:
+  host: jaeger.bookem.local
+
+configmap:
+  data:
+    SPAN_STORAGE_TYPE: badger
+    BADGER_EPHEMERAL: "false"
+    BADGER_DIRECTORY_VALUE: /badger/data
+    BADGER_DIRECTORY_KEY: /badger/key
+
+volumes:
+  dbStorage:
+    path: /badger
+    space: 1Gi

--- a/notes/README.md
+++ b/notes/README.md
@@ -1325,11 +1325,11 @@ configmap:
     BADGER_DIRECTORY_KEY: /badger/key
 ```
 
-Basicallu, we need to tell Jaeger what to do with persistency for storage.
+Basically, we need to tell Jaeger what to do with persistency for storage.
 `memory` is the "default" one which doesn't save. `elasticsearch` and `cassandra`
 are too bloated for our purposes, so `badger` it is.
 
-We also need to add anothe values to `hosts`:
+We also need to add another value to `hosts`:
 
 ```
 127.0.0.1 jaeger.bookem.local

--- a/reservation-service/templates/configmap.yml
+++ b/reservation-service/templates/configmap.yml
@@ -10,3 +10,6 @@ data:
   DB_USER: {{ .Values.configmap.data.DB_USER | quote }}
   DB_PASSWORD: {{ .Values.configmap.data.DB_PASSWORD | quote }}
   JWT_PUBLIC_KEY_PATH: {{ .Values.configmap.data.JWT_PUBLIC_KEY_PATH | quote }}
+  SERVICE_NAME: {{ .Values.configmap.data.SERVICE_NAME | quote }}
+  DEPLOYMENT_ENV: {{ .Values.configmap.data.DEPLOYMENT_ENV | quote }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.configmap.data.OTEL_EXPORTER_OTLP_ENDPOINT | quote }}

--- a/reservation-service/values.yaml
+++ b/reservation-service/values.yaml
@@ -3,7 +3,7 @@ namespace: default
 replicas: 1
 image:
   name: magley/bookem-reservation-service
-  tag: "nightly-0.1.0"
+  tag: "0.4.0"
 port: "8080"
 
 configmap:

--- a/reservation-service/values.yaml
+++ b/reservation-service/values.yaml
@@ -14,3 +14,6 @@ configmap:
     DB_USER: bookem_reservationdb_user
     DB_PASSWORD: password123
     JWT_PUBLIC_KEY_PATH: /app/keys/public_key.pem
+    SERVICE_NAME: reservation-service
+    DEPLOYMENT_ENV: prod
+    OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318

--- a/room-image-server/values.yaml
+++ b/room-image-server/values.yaml
@@ -3,7 +3,7 @@ namespace: default
 replicas: 1
 image:
   name: magley/bookem-room-images-server
-  tag: "nightly-0.0.1"
+  tag: "0.5.0"
 port: "80"
 
 volumes:

--- a/room-service/templates/configmap.yml
+++ b/room-service/templates/configmap.yml
@@ -10,3 +10,7 @@ data:
   DB_USER: {{ .Values.configmap.data.DB_USER | quote }}
   DB_PASSWORD: {{ .Values.configmap.data.DB_PASSWORD | quote }}
   JWT_PUBLIC_KEY_PATH: {{ .Values.configmap.data.JWT_PUBLIC_KEY_PATH | quote }}
+  JWT_PUBLIC_KEY_PATH: {{ .Values.configmap.data.JWT_PUBLIC_KEY_PATH | quote }}
+  SERVICE_NAME: {{ .Values.configmap.data.SERVICE_NAME | quote }}
+  DEPLOYMENT_ENV: {{ .Values.configmap.data.DEPLOYMENT_ENV | quote }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.configmap.data.OTEL_EXPORTER_OTLP_ENDPOINT | quote }}

--- a/room-service/values.yaml
+++ b/room-service/values.yaml
@@ -14,6 +14,9 @@ configmap:
     DB_USER: bookem_roomdb_user
     DB_PASSWORD: password123
     JWT_PUBLIC_KEY_PATH: /app/keys/public_key.pem
+    SERVICE_NAME: room-service
+    DEPLOYMENT_ENV: prod
+    OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
 
 volumes:
   nginxImageStorage:

--- a/room-service/values.yaml
+++ b/room-service/values.yaml
@@ -3,7 +3,7 @@ namespace: default
 replicas: 1
 image:
   name: magley/bookem-room-service
-  tag: "nightly-0.1.0"
+  tag: "0.5.0"
 port: "8080"
 
 configmap:

--- a/user-service/templates/configmap.yml
+++ b/user-service/templates/configmap.yml
@@ -11,3 +11,6 @@ data:
   DB_PASSWORD: {{ .Values.configmap.data.DB_PASSWORD | quote }}
   JWT_PRIVATE_KEY_PATH: {{ .Values.configmap.data.JWT_PRIVATE_KEY_PATH | quote }}
   JWT_PUBLIC_KEY_PATH: {{ .Values.configmap.data.JWT_PUBLIC_KEY_PATH | quote }}
+  SERVICE_NAME: {{ .Values.configmap.data.SERVICE_NAME | quote }}
+  DEPLOYMENT_ENV: {{ .Values.configmap.data.DEPLOYMENT_ENV | quote }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.configmap.data.OTEL_EXPORTER_OTLP_ENDPOINT | quote }}

--- a/user-service/values.yaml
+++ b/user-service/values.yaml
@@ -3,7 +3,7 @@ namespace: default
 replicas: 1
 image:
   name: magley/bookem-user-service
-  tag: "nightly-0.1.0"
+  tag: "a2025_09_25_01"
 port: "8080"
 
 configmap:
@@ -15,3 +15,6 @@ configmap:
     DB_PASSWORD: password123
     JWT_PRIVATE_KEY_PATH: /app/keys/private_key.key
     JWT_PUBLIC_KEY_PATH: /app/keys/public_key.pem
+    SERVICE_NAME: user-service
+    DEPLOYMENT_ENV: prod
+    OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318

--- a/user-service/values.yaml
+++ b/user-service/values.yaml
@@ -3,7 +3,7 @@ namespace: default
 replicas: 1
 image:
   name: magley/bookem-user-service
-  tag: "a2025_09_25_01"
+  tag: "0.3.0"
 port: "8080"
 
 configmap:

--- a/web-app/values.yaml
+++ b/web-app/values.yaml
@@ -3,7 +3,7 @@ namespace: default
 replicas: 1
 image:
   name: magley/bookem-web-app
-  tag: "nightly-0.3.13"
+  tag: "0.1.0"
 port: "80"
 publicPort: 30000
 


### PR DESCRIPTION
Tracing works on Kubernetes now. Visit `http://jaeger.bookem.local` for the dashboard. You'll also have to create a `jaeger.bookem.local` rule in _hosts_.

I know the branch is called "feature-tracing-user-service", but I've added tracing for the other microservices in here as well.